### PR TITLE
Add preview photo option and category discount control

### DIFF
--- a/bot/database/methods/create.py
+++ b/bot/database/methods/create.py
@@ -47,10 +47,10 @@ def add_values_to_item(item_name: str, value: str, is_infinity: bool) -> None:
     session.commit()
 
 
-def create_category(category_name: str, parent: str | None = None) -> None:
+def create_category(category_name: str, parent: str | None = None, allow_discounts: bool = True) -> None:
     session = Database().session
     session.add(
-        Categories(name=category_name, parent_name=parent))
+        Categories(name=category_name, parent_name=parent, allow_discounts=allow_discounts))
     session.commit()
 
 

--- a/bot/database/methods/read.py
+++ b/bot/database/methods/read.py
@@ -239,6 +239,23 @@ def check_category(category_name: str) -> dict | None:
     return result.__dict__ if result else None
 
 
+def can_use_discount(item_name: str) -> bool:
+    """Return True if item's main category allows discounts."""
+    session = Database().session
+    category_name = session.query(Goods.category_name).filter(Goods.name == item_name).scalar()
+    if not category_name:
+        return True
+    while True:
+        category = session.query(Categories.parent_name, Categories.allow_discounts) \
+            .filter(Categories.name == category_name).first()
+        if not category:
+            return True
+        parent, allow = category
+        if parent is None:
+            return bool(allow)
+        category_name = parent
+
+
 def get_item_value(item_name: str) -> dict | None:
     result = Database().session.query(ItemValues).filter(ItemValues.item_name == item_name).first()
     return result.__dict__ if result else None

--- a/bot/database/models/main.py
+++ b/bot/database/models/main.py
@@ -110,11 +110,13 @@ class Categories(Database.BASE):
     __tablename__ = 'categories'
     name = Column(String(100), primary_key=True, unique=True, nullable=False)
     parent_name = Column(String(100), nullable=True)
+    allow_discounts = Column(Boolean, nullable=False, default=True)
     item = relationship("Goods", back_populates="category")
 
-    def __init__(self, name: str, parent_name: str | None = None):
+    def __init__(self, name: str, parent_name: str | None = None, allow_discounts: bool = True):
         self.name = name
         self.parent_name = parent_name
+        self.allow_discounts = allow_discounts
 
 
 class Goods(Database.BASE):

--- a/bot/handlers/admin/shop_management_states.py
+++ b/bot/handlers/admin/shop_management_states.py
@@ -741,7 +741,6 @@ async def process_main_category_for_add(message: Message):
     bot, user_id = await get_bot_user_ids(message)
     msg = message.text
     message_id = TgConfig.STATE.get(f'{user_id}_message_id')
-    TgConfig.STATE[user_id] = None
     category = check_category(msg)
     await bot.delete_message(chat_id=message.chat.id,
                              message_id=message.message_id)
@@ -750,15 +749,33 @@ async def process_main_category_for_add(message: Message):
                                     message_id=message_id,
                                     text='❌ Main category not created (already exists)',
                                     reply_markup=back('categories_management'))
+        TgConfig.STATE[user_id] = None
         return
-    create_category(msg)
+    TgConfig.STATE[f'{user_id}_new_main_category'] = msg
+    TgConfig.STATE[user_id] = 'add_main_category_discount'
     await bot.edit_message_text(chat_id=message.chat.id,
+                                message_id=message_id,
+                                text='Let users use discounts in this main category?',
+                                reply_markup=question_buttons('maincat_discount', 'categories_management'))
+
+
+async def main_category_discount_decision(call: CallbackQuery):
+    bot, user_id = await get_bot_user_ids(call)
+    if TgConfig.STATE.get(user_id) != 'add_main_category_discount':
+        return
+    allow = call.data.endswith('_yes')
+    name = TgConfig.STATE.pop(f'{user_id}_new_main_category', None)
+    message_id = TgConfig.STATE.get(f'{user_id}_message_id')
+    TgConfig.STATE[user_id] = None
+    if not name:
+        return
+    create_category(name, allow_discounts=allow)
+    await bot.edit_message_text(chat_id=call.message.chat.id,
                                 message_id=message_id,
                                 text='✅ Main category created',
                                 reply_markup=back('categories_management'))
     admin_info = await bot.get_chat(user_id)
-    logger.info(f"User {user_id} ({admin_info.first_name}) "
-                f'created new main category "{msg}"')
+    logger.info(f"User {user_id} ({admin_info.first_name}) created new main category \"{name}\"")
 
 
 async def process_category_name(message: Message):
@@ -1001,11 +1018,30 @@ async def add_item_price(message: Message):
                                     reply_markup=back('item-management'))
         return
     TgConfig.STATE[f'{user_id}_price'] = message.text
-    TgConfig.STATE[user_id] = 'create_item_photo'
+    TgConfig.STATE[user_id] = 'create_item_preview'
     await bot.edit_message_text(chat_id=message.chat.id,
                                 message_id=message_id,
-                                text='Send preview photo for item:',
+                                text='Do you want to add a preview photo?',
+                                reply_markup=question_buttons('add_preview', 'item-management'))
+
+
+async def add_preview_yes(call: CallbackQuery):
+    bot, user_id = await get_bot_user_ids(call)
+    if TgConfig.STATE.get(user_id) != 'create_item_preview':
+        return
+    TgConfig.STATE[user_id] = 'create_item_photo'
+    await bot.edit_message_text('Send preview photo for item:',
+                                chat_id=call.message.chat.id,
+                                message_id=call.message.message_id,
                                 reply_markup=back('item-management'))
+
+
+async def add_preview_no(call: CallbackQuery):
+    bot, user_id = await get_bot_user_ids(call)
+    if TgConfig.STATE.get(user_id) != 'create_item_preview':
+        return
+    TgConfig.STATE[user_id] = None
+    await add_item_choose_category(call)
 
 
 async def add_item_preview_photo(message: Message):
@@ -1584,6 +1620,14 @@ def register_shop_management(dp: Dispatcher) -> None:
                                        lambda c: c.data.startswith('promo_expiry_') and TgConfig.STATE.get(c.from_user.id) == 'promo_create_expiry_type')
     dp.register_callback_query_handler(promo_manage_expiry_type_handler,
                                        lambda c: c.data.startswith('promo_expiry_') and TgConfig.STATE.get(c.from_user.id) == 'promo_manage_expiry_type')
+
+    dp.register_callback_query_handler(main_category_discount_decision,
+                                       lambda c: c.data.startswith('maincat_discount_') and TgConfig.STATE.get(c.from_user.id) == 'add_main_category_discount')
+
+    dp.register_callback_query_handler(add_preview_yes,
+                                       lambda c: c.data == 'add_preview_yes' and TgConfig.STATE.get(c.from_user.id) == 'create_item_preview')
+    dp.register_callback_query_handler(add_preview_no,
+                                       lambda c: c.data == 'add_preview_no' and TgConfig.STATE.get(c.from_user.id) == 'create_item_preview')
 
     dp.register_message_handler(check_item_name_for_amount_upd,
                                 lambda c: TgConfig.STATE.get(c.from_user.id) == 'update_amount_of_item')


### PR DESCRIPTION
## Summary
- Ask whether to add a preview photo when creating items and handle both responses
- Allow main categories to disable discounts and hide promo codes accordingly
- Fix reseller purchase error by handling messages without text

## Testing
- `pytest`
- `python -m py_compile bot/database/models/main.py bot/database/methods/create.py bot/database/methods/read.py bot/handlers/admin/shop_management_states.py bot/handlers/user/main.py`


------
https://chatgpt.com/codex/tasks/task_e_68bdfdec481c8332b5c1261b4e67e4ed