### PR TITLE
Add preview photo option and category discount/referral control

### DIFF
--- a/bot/database/methods/create.py
+++ b/bot/database/methods/create.py
@@ -47,10 +47,17 @@ def add_values_to_item(item_name: str, value: str, is_infinity: bool) -> None:
     session.commit()
 
 
-def create_category(category_name: str, parent: str | None = None) -> None:
+def create_category(category_name: str, parent: str | None = None,
+                    allow_discounts: bool = True, allow_referral_rewards: bool = True) -> None:
     session = Database().session
     session.add(
-        Categories(name=category_name, parent_name=parent))
+        Categories(
+            name=category_name,
+            parent_name=parent,
+            allow_discounts=allow_discounts,
+            allow_referral_rewards=allow_referral_rewards,
+        )
+    )
     session.commit()
 
 

--- a/bot/database/methods/read.py
+++ b/bot/database/methods/read.py
@@ -239,6 +239,40 @@ def check_category(category_name: str) -> dict | None:
     return result.__dict__ if result else None
 
 
+def can_use_discount(item_name: str) -> bool:
+    """Return True if item's main category allows discounts."""
+    session = Database().session
+    category_name = session.query(Goods.category_name).filter(Goods.name == item_name).scalar()
+    if not category_name:
+        return True
+    while True:
+        category = session.query(Categories.parent_name, Categories.allow_discounts) \
+            .filter(Categories.name == category_name).first()
+        if not category:
+            return True
+        parent, allow = category
+        if parent is None:
+            return bool(allow)
+        category_name = parent
+
+
+def can_get_referral_reward(item_name: str) -> bool:
+    """Return True if item's main category allows referral rewards."""
+    session = Database().session
+    category_name = session.query(Goods.category_name).filter(Goods.name == item_name).scalar()
+    if not category_name:
+        return True
+    while True:
+        category = session.query(Categories.parent_name, Categories.allow_referral_rewards) \
+            .filter(Categories.name == category_name).first()
+        if not category:
+            return True
+        parent, allow = category
+        if parent is None:
+            return bool(allow)
+        category_name = parent
+
+
 def get_item_value(item_name: str) -> dict | None:
     result = Database().session.query(ItemValues).filter(ItemValues.item_name == item_name).first()
     return result.__dict__ if result else None

--- a/bot/database/models/main.py
+++ b/bot/database/models/main.py
@@ -110,11 +110,16 @@ class Categories(Database.BASE):
     __tablename__ = 'categories'
     name = Column(String(100), primary_key=True, unique=True, nullable=False)
     parent_name = Column(String(100), nullable=True)
+    allow_discounts = Column(Boolean, nullable=False, default=True)
+    allow_referral_rewards = Column(Boolean, nullable=False, default=True)
     item = relationship("Goods", back_populates="category")
 
-    def __init__(self, name: str, parent_name: str | None = None):
+    def __init__(self, name: str, parent_name: str | None = None,
+                 allow_discounts: bool = True, allow_referral_rewards: bool = True):
         self.name = name
         self.parent_name = parent_name
+        self.allow_discounts = allow_discounts
+        self.allow_referral_rewards = allow_referral_rewards
 
 
 class Goods(Database.BASE):

--- a/bot/handlers/user/main.py
+++ b/bot/handlers/user/main.py
@@ -25,6 +25,7 @@ from bot.database.methods import (
     select_unfinished_operations, get_user_referral, finish_operation, update_balance, create_operation,
     bought_items_list, check_value, get_subcategories, get_category_parent, get_user_language, update_user_language,
     get_unfinished_operation, get_user_unfinished_operation, get_promocode, add_values_to_item, get_user_tickets, update_lottery_tickets,
+    can_use_discount, can_get_referral_reward,
     has_user_achievement, get_achievement_users, grant_achievement, get_user_count,
     get_out_of_stock_categories, get_out_of_stock_subcategories, get_out_of_stock_items,
     has_stock_notification, add_stock_notification, check_user_by_username, check_user_referrals,
@@ -1028,16 +1029,29 @@ async def confirm_buy_callback_handler(call: CallbackQuery):
     TgConfig.STATE[f'{user_id}_pending_item'] = item_name
     TgConfig.STATE[f'{user_id}_price'] = price
     text = t(lang, 'confirm_purchase', item=display_name(item_name), price=price)
-    await bot.edit_message_text(
-        chat_id=call.message.chat.id,
-        message_id=call.message.message_id,
-        text=text,
-        reply_markup=confirm_purchase_menu(item_name, lang)
-    )
+    show_promo = can_use_discount(item_name)
+    if call.message.text:
+        await bot.edit_message_text(
+            chat_id=call.message.chat.id,
+            message_id=call.message.message_id,
+            text=text,
+            reply_markup=confirm_purchase_menu(item_name, lang, show_promo=show_promo)
+        )
+    else:
+        await bot.send_message(
+            user_id,
+            text,
+            reply_markup=confirm_purchase_menu(item_name, lang, show_promo=show_promo)
+        )
+        with contextlib.suppress(Exception):
+            await call.message.delete()
 
 async def apply_promo_callback_handler(call: CallbackQuery):
     item_name = call.data[len('applypromo_'):]
     bot, user_id = await get_bot_user_ids(call)
+    if not can_use_discount(item_name):
+        await call.answer('Promos not allowed for this category', show_alert=True)
+        return
     if TgConfig.STATE.get(f'{user_id}_promo_applied'):
         await call.answer('Promo code already applied', show_alert=True)
         return
@@ -1107,7 +1121,7 @@ async def buy_item_callback_handler(call: CallbackQuery):
                 add_bought_item(value_data['item_name'], value_data['value'], item_price, user_id, formatted_time)
 
             referral_id = get_user_referral(user_id)
-            if referral_id and TgConfig.REFERRAL_PERCENT:
+            if referral_id and TgConfig.REFERRAL_PERCENT and can_get_referral_reward(value_data['item_name']):
                 reward = round(item_price * TgConfig.REFERRAL_PERCENT / 100, 2)
                 update_balance(referral_id, reward)
                 ref_lang = get_user_language(referral_id) or 'en'
@@ -1853,7 +1867,7 @@ async def checking_payment(call: CallbackQuery):
                     except Exception:
                         pass
 
-                if referral_id and TgConfig.REFERRAL_PERCENT:
+                if referral_id and TgConfig.REFERRAL_PERCENT and can_get_referral_reward(item_name):
                     reward = round(price * TgConfig.REFERRAL_PERCENT / 100, 2)
                     update_balance(referral_id, reward)
                     ref_lang = get_user_language(referral_id) or 'en'


### PR DESCRIPTION
## Summary
- Ask whether to add a preview photo when creating items and handle both responses
- Allow main categories to disable discounts and hide promo codes accordingly
- Fix reseller purchase error by handling messages without text
- Let admins toggle referral rewards for main categories and honor that setting when awarding bonuses

## Testing
- `pytest`
- `python -m py_compile bot/database/models/main.py bot/database/methods/create.py bot/database/methods/read.py bot/handlers/admin/shop_management_states.py bot/handlers/user/main.py`


------
https://chatgpt.com/codex/tasks/task_e_68bdfdec481c8332b5c1261b4e67e4ed